### PR TITLE
Improve RSpec failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add negation rspec matcher: `have_not_delivered_to`. ([@StanisLove][])
 
+- Improve RSpec matcher's failure message. ([@iBublik][])
+
 ## 0.2.1 (2018-01-15)
 
 - Backport `ActionMailer::Paremeterized` for Rails <5. ([@palkan][])

--- a/lib/active_delivery/testing/rspec.rb
+++ b/lib/active_delivery/testing/rspec.rb
@@ -136,7 +136,7 @@ module ActiveDelivery
     end
 
     def count_failure_message
-      diff = @matching_count - @expected_count
+      diff = @matching_count - @expected_number
       if diff.positive?
         "#{diff} extra item(s)"
       else

--- a/lib/active_delivery/testing/rspec.rb
+++ b/lib/active_delivery/testing/rspec.rb
@@ -97,14 +97,12 @@ module ActiveDelivery
         msg << "\n#{message_expectation_modifier}, but"
 
         if @unmatching_deliveries.any?
-          msg << " delivered the following notifications:"
-          @unmatching_deliveries.each do |(delivery, event, args, options)|
-            msg << "\n  :#{event} via #{delivery.class}" \
-                  "#{options[:sync] ? " (sync)" : ""}" \
-                  " with:" \
-                  "\n   - params: #{delivery.params.empty? ? "<none>" : delivery.params.to_s}" \
-                  "\n   - args: #{args}"
-          end
+          msg << " delivered the following unexpected notifications:"
+          msg << deliveries_description(@unmatching_deliveries)
+        elsif @matching_count.positive?
+          msg << " delivered #{@matching_count} matching notifications" \
+                 " (#{count_failure_message}):"
+          msg << deliveries_description(@matching_deliveries)
         else
           msg << " haven't delivered anything"
         end
@@ -134,6 +132,25 @@ module ActiveDelivery
       when :exactly then "exactly #{number_modifier}"
       when :at_most then "at most #{number_modifier}"
       when :at_least then "at least #{number_modifier}"
+      end
+    end
+
+    def count_failure_message
+      diff = @matching_count - @expected_count
+      if diff.positive?
+        "#{diff} extra item(s)"
+      else
+        "#{diff} missing item(s)"
+      end
+    end
+
+    def deliveries_description(deliveries)
+      deliveries.each.with_object(+"") do |(delivery, event, args, options), msg|
+        msg << "\n  :#{event} via #{delivery.class}" \
+              "#{options[:sync] ? " (sync)" : ""}" \
+              " with:" \
+              "\n   - params: #{delivery.params.empty? ? "<none>" : delivery.params.to_s}" \
+              "\n   - args: #{args}"
       end
     end
 


### PR DESCRIPTION
Currently when matcher fails due to matched deliveries count and there're no mismatching deliveries, message has confusing text "but haven't delivered anything"

For example
```ruby
class MyDeliveryService
  def self.call
    2.times { MyDelivery.notify(:test) }
  end
end

describe MyDeliveryService
  specify do
    expect { described_class.call }.to have_delivered_to(MyDelivery).once 
  end
end
```
will fail with message `expected to deliver via MyDelivery exactly once, but haven't delivered anything`. The actual reason is 1 extra performed delivery