### PR TITLE
Add support for testing fibers using TestDelivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fixed TestDelivery fiber support. ([@pauldub](https://github.com/pauldub))
+
 ## 0.4.0 (2020-03-02)
 
 - **Drop Ruby 2.4 support**. ([@palkan][])

--- a/lib/active_delivery/testing.rb
+++ b/lib/active_delivery/testing.rb
@@ -7,15 +7,15 @@ module ActiveDelivery
         raise ArgumentError, "block is required" unless block_given?
         begin
           clear
-          Thread.current[:active_delivery_testing] = true
+          Thread.current.thread_variable_set(:active_delivery_testing, true)
           yield
         ensure
-          Thread.current[:active_delivery_testing] = false
+          Thread.current.thread_variable_set(:active_delivery_testing, false)
         end
       end
 
       def enabled?
-        Thread.current[:active_delivery_testing] == true
+        Thread.current.thread_variable_get(:active_delivery_testing) == true
       end
 
       def track(delivery, event, args, options)

--- a/spec/active_delivery/rspec_spec.rb
+++ b/spec/active_delivery/rspec_spec.rb
@@ -114,4 +114,18 @@ describe "RSpec matcher" do
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
+
+  context "fibers" do
+    specify "success" do
+      expect { Fiber.new { delivery.notify(:send_something, "data", 42) }.resume }
+        .to have_delivered_to(delivery)
+    end
+
+    specify "failure" do
+      expect do
+        expect { Fiber.new { delivery.notify(:send_something) }.resume }
+          .to have_delivered_to(delivery, :send_smth)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #17 by using `thread_variable_set` and `thread_variable_get`
methods in order to persist thread-local instead of fiber-local testing state.