### PR TITLE
Allow resolve mailer class with custom pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Allow resolve mailer class with custom pattern ([@brovikov][])
+
 ## 0.4.1 (2020-04-22)
 
 - Fixed TestDelivery fiber support. ([@pauldub](https://github.com/pauldub))

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ PostsNotifier.published(user, post).notify_later
 
 P.S. Naming ("delivery") is inspired by Basecamp: https://www.youtube.com/watch?v=m1jOWu7woKM.
 
+**NOTE**: You could specify Mailer class explicitly or by custom pattern, using resolver:
+
+```ruby
+class PostsDelivery < ActiveDelivery::Base
+  register_line :custom_mailer, ActiveDelivery::Lines::Mailer, resolver: ->(name) { CustomMailer }
+end
+```
+
 Delivery also supports _parameterized_ calling:
 
 ```ruby

--- a/lib/active_delivery/lines/base.rb
+++ b/lib/active_delivery/lines/base.rb
@@ -7,8 +7,6 @@ module ActiveDelivery
       attr_accessor :owner
       attr_writer :handler_class
 
-      DEFAULT_RESOLVER = ->(name) { name.gsub(/Delivery$/, "Notifier").safe_constantize }
-
       def initialize(id:, owner:, **options)
         @id = id
         @owner = owner

--- a/lib/active_delivery/lines/base.rb
+++ b/lib/active_delivery/lines/base.rb
@@ -7,10 +7,13 @@ module ActiveDelivery
       attr_accessor :owner
       attr_writer :handler_class
 
+      DEFAULT_RESOLVER = ->(name) { name.gsub(/Delivery$/, "Notifier").safe_constantize }
+
       def initialize(id:, owner:, **options)
         @id = id
         @owner = owner
         @options = options.tap(&:freeze)
+        @resolver = options[:resolver]
       end
 
       def dup_for(new_owner)
@@ -18,6 +21,7 @@ module ActiveDelivery
       end
 
       def resolve_class(name)
+        resolver&.call(name)
       end
 
       def notify?(method_name)
@@ -54,6 +58,8 @@ module ActiveDelivery
 
         owner.superclass.public_send(handler_method)
       end
+
+      attr_reader :resolver
     end
   end
 end

--- a/lib/active_delivery/lines/mailer.rb
+++ b/lib/active_delivery/lines/mailer.rb
@@ -9,9 +9,7 @@ module ActiveDelivery
     class Mailer < Base
       alias mailer_class handler_class
 
-      def resolve_class(name)
-        name.gsub(/Delivery$/, "Mailer").safe_constantize
-      end
+      DEFAULT_RESOLVER = ->(name) { name.gsub(/Delivery$/, "Mailer").safe_constantize }
 
       def notify?(method_name)
         mailer_class.action_methods.include?(method_name.to_s)
@@ -34,6 +32,6 @@ module ActiveDelivery
       end
     end
 
-    ActiveDelivery::Base.register_line :mailer, Mailer
+    ActiveDelivery::Base.register_line :mailer, Mailer, resolver: Mailer::DEFAULT_RESOLVER
   end
 end

--- a/spec/active_delivery/lines/mailer_spec.rb
+++ b/spec/active_delivery/lines/mailer_spec.rb
@@ -20,7 +20,11 @@ describe "ActionMailer line" do
         end
       end
 
+      class CustomMailer < ActionMailer::Base
+      end
+
       class TestDelivery < ActiveDelivery::Base
+        register_line :custom_mailer, ActiveDelivery::Lines::Mailer, resolver: ->(name) { CustomMailer }
       end
     end
   end
@@ -31,10 +35,17 @@ describe "ActionMailer line" do
 
   let(:delivery_class) { ::DeliveryTesting::TestDelivery }
   let(:mailer_class) { ::DeliveryTesting::TestMailer }
+  let(:custom_mailer_class) { ::DeliveryTesting::CustomMailer }
 
   describe ".mailer_class" do
     it "infers mailer from delivery name" do
       expect(delivery_class.mailer_class).to be_eql(mailer_class)
+    end
+  end
+
+  describe ".custom_mailer_class" do
+    it "infers mailer from resolver" do
+      expect(delivery_class.custom_mailer_class).to be_eql(custom_mailer_class)
     end
   end
 


### PR DESCRIPTION
* Moves the resolving logic to `ActiveDelivery::Lines::Base`
* Updates `ActiveDelivery::Lines::Mailer` with ability use custom resolver

Fixes #16 