### PR TITLE
Add support of ActionMailer::Parameterized to ActionMailer >= 5.0, < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
         - NO_RAILS=1
     - rvm: 2.5
       gemfile: gemfiles/rails42.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails50.gemfile
   allow_failures:
     - rvm: ruby-head
       gemfile: gemfiles/railsmaster.gemfile

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.0.7"
+gem "actionmailer", "~> 5.0.7"
+
+gemspec path: ".."

--- a/lib/active_delivery/action_mailer/parameterized.rb
+++ b/lib/active_delivery/action_mailer/parameterized.rb
@@ -43,6 +43,8 @@ module ActionMailer
     class MessageDelivery < ActionMailer::MessageDelivery # :nodoc:
       def initialize(mailer_class, action, params, *args)
         super(mailer_class, action, *args)
+        @mailer ||= mailer_class
+        @mail_method ||= action
         @params = params
       end
 
@@ -57,10 +59,14 @@ module ActionMailer
       private
 
       def processed_mailer
-        @processed_mailer ||= @mailer.send(:new, nil, *@args).tap do |m|
+        @processed_mailer ||= @mailer.send(*mailer_args).tap do |m|
           m.params = @params
           m.process @mail_method, *@args
         end
+      end
+
+      def mailer_args
+        ActionMailer::VERSION::MAJOR < 5 ? [:new, nil, *@args] : [:new]
       end
 
       def enqueue_delivery(delivery_method, options = {})

--- a/lib/active_delivery/lines/mailer.rb
+++ b/lib/active_delivery/lines/mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ActionMailer::VERSION::MAJOR < 5
+if ActionMailer::VERSION::MAJOR < 5 || (ActionMailer::VERSION::MAJOR == 5 && ActionMailer::VERSION::MINOR < 2)
   require "active_delivery/action_mailer/parameterized"
 end
 

--- a/spec/active_delivery/lines/mailer_spec.rb
+++ b/spec/active_delivery/lines/mailer_spec.rb
@@ -49,6 +49,16 @@ describe "ActionMailer line" do
     end
   end
 
+  describe ".with" do
+    it "doesn't raises error" do
+      expect { delivery_class.with(test_param: true).notify(:do_something) }.not_to raise_error
+    end
+
+    it "sets params" do
+      expect(delivery_class.with(test_param: true).params).to eq(test_param: true)
+    end
+  end
+
   describe ".notify" do
     let(:mailer_instance) { double("mailer") }
 


### PR DESCRIPTION
## Problem
`ActionMailer::Parameterized` added at ActionMailer 5.2, that means there is no way to use this gem with `.with` on rails 5.0 (I know, I should update, but it's in process).

## Solution
I found inside this gem support for Rails 4, and extended it to support <5.2 as well