### PR TITLE
Add ActiveDelivery::Base.unregister_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.4.4 (2020-08-28)
+
+- Added `ActiveDelivery::Base.unregister_line` ([@thornomad][])
+
 ## 0.4.3 (2020-08-21)
 
 - Fix parameterized mailers support in Rails >= 5.0, <5.2 ([@dmitryzuev][])
@@ -53,3 +57,4 @@ Initial version.
 [@iBublik]: https://github.com/ibublik
 [@brovikov]: https://github.com/brovikov
 [@dmitryzuev]: https://github.com/dmitryzuev
+[@thornomad]: https://github.com/thornomad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## master
 
-## 0.4.4 (2020-08-28)
-
 - Added `ActiveDelivery::Base.unregister_line` ([@thornomad][])
 
 ## 0.4.3 (2020-08-21)

--- a/README.md
+++ b/README.md
@@ -303,6 +303,15 @@ class EventDelivery < ActiveDelivery::Base
 end
 ```
 
+You can also _unregister_ a line.  For example, when subclassing another `Delivery` class or to remove any of the automatically added lines (e.g., `mailer`):
+
+```ruby
+class NonMailerDelivery < ActiveDelivery::Base
+  # Use unregister_line to remove any default or inherited lines
+  unregister_line :mailer
+end
+```
+
 ## Related projects
 
 - [`abstract_notifier`](https://github.com/palkan/abstract_notifier) – Action Mailer-like interface for text-based notifications.

--- a/lib/active_delivery/base.rb
+++ b/lib/active_delivery/base.rb
@@ -73,6 +73,10 @@ module ActiveDelivery
         CODE
       end
 
+      def unregister_line(line_id)
+        delivery_lines.delete(line_id)
+      end
+
       def abstract_class?
         abstract_class == true
       end

--- a/lib/active_delivery/base.rb
+++ b/lib/active_delivery/base.rb
@@ -74,7 +74,12 @@ module ActiveDelivery
       end
 
       def unregister_line(line_id)
-        delivery_lines.delete(line_id)
+        removed_line = delivery_lines.delete(line_id)
+
+        return if removed_line.nil?
+
+        singleton_class.undef_method line_id
+        singleton_class.undef_method "#{line_id}_class"
       end
 
       def abstract_class?

--- a/spec/active_delivery/base_spec.rb
+++ b/spec/active_delivery/base_spec.rb
@@ -147,6 +147,20 @@ describe ActiveDelivery::Base do
     end
   end
 
+  describe ".unregister_line" do
+    it "removes the line indicated by the line_id argument" do
+      expect(delivery_class.delivery_lines.keys).to include(:quack_quack)
+
+      delivery_class.unregister_line :quack_quack
+
+      expect(delivery_class.delivery_lines.keys).not_to include(:quack_quack)
+    end
+
+    it "does not raise an error if the line does not exist" do
+      expect { delivery_class.unregister_line(:what_does_the_fox_say) }.not_to raise_error
+    end
+  end
+
   describe ".with" do
     let!(:quack_class) do
       DeliveryTesting.const_set(

--- a/spec/active_delivery/base_spec.rb
+++ b/spec/active_delivery/base_spec.rb
@@ -159,6 +159,23 @@ describe ActiveDelivery::Base do
     it "does not raise an error if the line does not exist" do
       expect { delivery_class.unregister_line(:what_does_the_fox_say) }.not_to raise_error
     end
+
+    context "when unregister_line on the class that registered the line the first time" do
+      it "unsets the <line>_class method" do
+        delivery_class = DeliveryTesting.const_set("MyDelivery", Class.new(described_class))
+
+        expect(delivery_class.respond_to?(:quack_quack_class)).to be true
+        expect(delivery_class.respond_to?(:quack_quack)).to be true
+
+        delivery_class.unregister_line :quack_quack
+
+        expect(delivery_class.respond_to?(:quack_quack_class)).to be false
+        expect(delivery_class.respond_to?(:quack_quack)).to be false
+
+        expect(ActiveDelivery::Base.respond_to?(:quack_quack_class)).to be true
+        expect(ActiveDelivery::Base.respond_to?(:quack_quack)).to be true
+      end
+    end
   end
 
   describe ".with" do


### PR DESCRIPTION
Removes a registered line and is silent when the line to be removed does not exist.  Fairly simple change did a minor version bump.  Feel free to edit as needed or request changes.

References palkan/abstract_notifier#8

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
