### PR TITLE
v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## master
 
+- Add ability to specify delivery actions explicitly and disable implicit proxying. ([@palkan][])
+
+You can disable default Active Delivery behaviour of proxying action methods to underlying lines via the `ActiveDelivery.deliver_actions_required = true` configuration option. Then, in each delivery class, you can specify the available actions via the `.delivers` method:
+
+```ruby
+class PostMailer < ApplicationMailer
+  def published(post)
+    # ...
+  end
+
+  def whatever(post)
+    # ...
+  end
+end
+
+ActiveDelivery.deliver_actions_required = true
+
+class PostDelivery < ApplicationDelivery
+  delivers :published
+end
+
+PostDelivery.published(post) #=> ok
+PostDelivery.whatever(post) #=> raises NoMethodError
+```
+
 - Add `#deliver_via(*lines)` RSpec matcher. ([@palkan][])
 
 - Provide ActionMailer-like interface to trigger notifications. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- **Merge in abstract_notifier** ([@palkan][])
+
+[Abstract Notifier](https://github.com/palkan/abstract_notifier) is now a part of Active Delivery.
+
 - Add ability to specify delivery actions explicitly and disable implicit proxying. ([@palkan][])
 
 You can disable default Active Delivery behaviour of proxying action methods to underlying lines via the `ActiveDelivery.deliver_actions_required = true` configuration option. Then, in each delivery class, you can specify the available actions via the `.delivers` method:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## master
 
+- Provide ActionMailer-like interface to trigger notifications. ([@palkan][])
+
+Now you can send notifications as follows:
+
+```ruby
+MyDelivery.with(user:).new_notification(payload).deliver_later
+
+# Equals to the old (and still supported)
+MyDelivery.with(user:).notify(:new_notification, payload)
+```
+
 - Support passing a string class name as a handler class. ([@palkan][])
 
 - Allow disabled handler classes cache and do not cache when Rails cache_classes is false. ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `#deliver_via(*lines)` RSpec matcher. ([@palkan][])
+
 - Provide ActionMailer-like interface to trigger notifications. ([@palkan][])
 
 Now you can send notifications as follows:

--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ describe PostsDelivery, type: :delivery do
   describe "#published" do
     it "delivers to mailer and sms" do
       expect {
-        described_class.published(user, post).deliver_now
-      }.to deliver_via(:mailer, :sms, mailer_class: PostsMailer)
+        described_class.published(user, post).deliver_later
+      }.to deliver_via(:mailer, :sms)
     end
 
     context "when user is not subscribed to SMS notifications" do

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ class PostsDelivery < ApplicationDelivery
 end
 ```
 
+Finally, you can disable the default automatic proxying behaviour via the `ActiveDelivery.deliver_actions_required = true` configuration option. Then, in each delivery class, you can specify the available actions via the `.delivers` method:
+
+```ruby
+class PostDelivery < ApplicationDelivery
+  delivers :published
+end
+
+ActiveDelivery.deliver_actions_required = true
+
+PostDelivery.published(post) #=> ok
+PostDelivery.whatever(post) #=> raises NoMethodError
+```
+
 ### Customizing delivery handlers
 
 You can specify a mailer class explicitly:

--- a/active_delivery.gemspec
+++ b/active_delivery.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 1.15"
   s.add_development_dependency "rake", ">= 13.0"
   s.add_development_dependency "rspec", ">= 3.9"
+  s.add_development_dependency "rspec-rails", ">= 4.0"
 
   # When gem is installed from source, we add `ruby-next` as a dependency
   # to auto-transpile source files during the first load

--- a/forspell.dict
+++ b/forspell.dict
@@ -7,3 +7,4 @@ matchers
 palkan
 testability
 pre-transpiled
+parameterization

--- a/lib/abstract_notifier.rb
+++ b/lib/abstract_notifier.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "abstract_notifier/version"
+
+# Abstract Notifier is responsible for generating and triggering text-based notifications
+# (like Action Mailer for email notifications).
+#
+# Example:
+#
+#   class ApplicationNotifier < AbstractNotifier::Base
+#     self.driver = NotifyService.new
+#
+#     def profile
+#       params[:profile] if params
+#     end
+#   end
+#
+#   class EventsNotifier < ApplicationNotifier
+#     def canceled(event)
+#       notification(
+#         # the only required option is `body`
+#         body: "Event #{event.title} has been canceled",
+#         # all other options are passed to delivery driver
+#         identity: profile.notification_service_id
+#       )
+#    end
+#   end
+#
+#   EventsNotifier.with(profile: profile).canceled(event).notify_later
+#
+module AbstractNotifier
+  DELIVERY_MODES = %i[test noop normal].freeze
+
+  class << self
+    attr_reader :delivery_mode
+    attr_reader :async_adapter
+
+    def delivery_mode=(val)
+      unless DELIVERY_MODES.include?(val)
+        raise ArgumentError, "Unsupported delivery mode: #{val}. " \
+                             "Supported values: #{DELIVERY_MODES.join(", ")}"
+      end
+
+      @delivery_mode = val
+    end
+
+    def async_adapter=(args)
+      adapter, options = Array(args)
+      @async_adapter = AsyncAdapters.lookup(adapter, options)
+    end
+
+    def noop?
+      delivery_mode == :noop
+    end
+
+    def test?
+      delivery_mode == :test
+    end
+  end
+
+  self.delivery_mode =
+    if ENV["RACK_ENV"] == "test" || ENV["RAILS_ENV"] == "test"
+      :test
+    else
+      :normal
+    end
+end
+
+require "abstract_notifier/base"
+require "abstract_notifier/async_adapters"
+
+require "abstract_notifier/async_adapters/active_job" if defined?(ActiveJob)
+
+require "abstract_notifier/testing" if ENV["RACK_ENV"] == "test" || ENV["RAILS_ENV"] == "test"

--- a/lib/abstract_notifier/async_adapters.rb
+++ b/lib/abstract_notifier/async_adapters.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  module AsyncAdapters
+    class << self
+      def lookup(adapter, options = nil)
+        return adapter unless adapter.is_a?(Symbol)
+
+        adapter_class_name = adapter.to_s.split("_").map(&:capitalize).join
+        AsyncAdapters.const_get(adapter_class_name).new(**(options || {}))
+      rescue NameError => e
+        raise e.class, "Notifier async adapter :#{adapter} haven't been found", e.backtrace
+      end
+    end
+  end
+end

--- a/lib/abstract_notifier/async_adapters/active_job.rb
+++ b/lib/abstract_notifier/async_adapters/active_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  module AsyncAdapters
+    class ActiveJob
+      class DeliveryJob < ::ActiveJob::Base
+        def perform(notifier_class, payload)
+          AbstractNotifier::Notification.new(notifier_class.constantize, payload).notify_now
+        end
+      end
+
+      DEFAULT_QUEUE = "notifiers"
+
+      attr_reader :job
+
+      def initialize(queue: DEFAULT_QUEUE, job: DeliveryJob)
+        @job = job.set(queue: queue)
+      end
+
+      def enqueue(notifier_class, payload)
+        job.perform_later(notifier_class.name, payload)
+      end
+    end
+  end
+end
+
+AbstractNotifier.async_adapter ||= :active_job

--- a/lib/abstract_notifier/base.rb
+++ b/lib/abstract_notifier/base.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  # Notificaiton payload wrapper which contains
+  # information about the current notifier class
+  # and knows how to trigger the delivery
+  class Notification
+    attr_reader :payload, :owner
+
+    def initialize(owner, payload)
+      @owner = owner
+      @payload = payload
+    end
+
+    def notify_later
+      return if AbstractNotifier.noop?
+      owner.async_adapter.enqueue owner, payload
+    end
+
+    def notify_now
+      return if AbstractNotifier.noop?
+      owner.driver.call(payload)
+    end
+  end
+
+  # Base class for notifiers
+  class Base
+    class ParamsProxy
+      attr_reader :notifier_class, :params
+
+      def initialize(notifier_class, params)
+        @notifier_class = notifier_class
+        @params = params
+      end
+
+      # rubocop:disable Style/MethodMissingSuper
+      def method_missing(method_name, *args, **kwargs)
+        if kwargs.empty?
+          notifier_class.new(method_name, **params).public_send(method_name, *args)
+        else
+          notifier_class.new(method_name, **params).public_send(method_name, *args, **kwargs)
+        end
+      end
+      # rubocop:enable Style/MethodMissingSuper
+
+      def respond_to_missing?(*args)
+        notifier_class.respond_to_missing?(*args)
+      end
+    end
+
+    class << self
+      attr_writer :driver
+
+      def driver
+        return @driver if instance_variable_defined?(:@driver)
+
+        @driver =
+          if superclass.respond_to?(:driver)
+            superclass.driver
+          else
+            raise "Driver not found for #{name}. " \
+                  "Please, specify driver via `self.driver = MyDriver`"
+          end
+      end
+
+      def async_adapter=(args)
+        adapter, options = Array(args)
+        @async_adapter = AsyncAdapters.lookup(adapter, options)
+      end
+
+      def async_adapter
+        return @async_adapter if instance_variable_defined?(:@async_adapter)
+
+        @async_adapter =
+          if superclass.respond_to?(:async_adapter)
+            superclass.async_adapter
+          else
+            AbstractNotifier.async_adapter
+          end
+      end
+
+      def default(method_name = nil, **hargs, &block)
+        return @defaults_generator = block if block
+
+        return @defaults_generator = proc { send(method_name) } unless method_name.nil?
+
+        @default_params =
+          if superclass.respond_to?(:default_params)
+            superclass.default_params.merge(hargs).freeze
+          else
+            hargs.freeze
+          end
+      end
+
+      def defaults_generator
+        return @defaults_generator if instance_variable_defined?(:@defaults_generator)
+
+        @defaults_generator =
+          if superclass.respond_to?(:defaults_generator)
+            superclass.defaults_generator
+          end
+      end
+
+      def default_params
+        return @default_params if instance_variable_defined?(:@default_params)
+
+        @default_params =
+          if superclass.respond_to?(:default_params)
+            superclass.default_params.dup
+          else
+            {}
+          end
+      end
+
+      def method_missing(method_name, *args)
+        if action_methods.include?(method_name.to_s)
+          new(method_name).public_send(method_name, *args)
+        else
+          super
+        end
+      end
+
+      def with(params)
+        ParamsProxy.new(self, params)
+      end
+
+      def respond_to_missing?(method_name, _include_private = false)
+        action_methods.include?(method_name.to_s) || super
+      end
+
+      # See https://github.com/rails/rails/blob/b13a5cb83ea00d6a3d71320fd276ca21049c2544/actionpack/lib/abstract_controller/base.rb#L74
+      def action_methods
+        @action_methods ||= begin
+          # All public instance methods of this class, including ancestors
+          methods = (public_instance_methods(true) -
+            # Except for public instance methods of Base and its ancestors
+            Base.public_instance_methods(true) +
+            # Be sure to include shadowed public instance methods of this class
+            public_instance_methods(false))
+
+          methods.map!(&:to_s)
+
+          methods.to_set
+        end
+      end
+    end
+
+    attr_reader :params, :notification_name
+
+    def initialize(notification_name, **params)
+      @notification_name = notification_name
+      @params = params.freeze
+    end
+
+    def notification(**payload)
+      merge_defaults!(payload)
+
+      raise ArgumentError, "Notification body must be present" if
+        payload[:body].nil? || payload[:body].empty?
+      Notification.new(self.class, payload)
+    end
+
+    private
+
+    def merge_defaults!(payload)
+      defaults =
+        if self.class.defaults_generator
+          instance_exec(&self.class.defaults_generator)
+        else
+          self.class.default_params
+        end
+
+      defaults.each do |k, v|
+        payload[k] = v unless payload.key?(k)
+      end
+    end
+  end
+end

--- a/lib/abstract_notifier/testing.rb
+++ b/lib/abstract_notifier/testing.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  module Testing
+    module Driver
+      class << self
+        def deliveries
+          Thread.current[:notifier_deliveries] ||= []
+        end
+
+        def enqueued_deliveries
+          Thread.current[:notifier_enqueued_deliveries] ||= []
+        end
+
+        def clear
+          deliveries.clear
+          enqueued_deliveries.clear
+        end
+
+        def send_notification(data)
+          deliveries << data
+        end
+
+        def enqueue_notification(data)
+          enqueued_deliveries << data
+        end
+      end
+    end
+
+    module Notification
+      def notify_now
+        return super unless AbstractNotifier.test?
+
+        Driver.send_notification payload.merge(via: owner)
+      end
+
+      def notify_later
+        return super unless AbstractNotifier.test?
+
+        Driver.enqueue_notification payload.merge(via: owner)
+      end
+    end
+  end
+end
+
+AbstractNotifier::Notification.prepend AbstractNotifier::Testing::Notification
+
+require "abstract_notifier/testing/rspec" if defined?(RSpec::Core)
+require "abstract_notifier/testing/minitest" if defined?(Minitest::Assertions)

--- a/lib/abstract_notifier/testing/minitest.rb
+++ b/lib/abstract_notifier/testing/minitest.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  module TestHelper
+    def assert_notifications_sent(count, params)
+      yield
+      assert_equal deliveries.count, count
+      count.times do |i|
+        delivery = deliveries[0 - i]
+        if !params[:via]
+          delivery = delivery.dup
+          delivery.delete(:via)
+        end
+
+        msg = message(msg) { "Expected #{mu_pp(delivery)} to include #{mu_pp(params)}" }
+        assert hash_include?(delivery, params), msg
+      end
+    end
+
+    def assert_notifications_enqueued(count, params)
+      yield
+      assert_equal enqueued_deliveries.count, count
+      count.times do |i|
+        delivery = enqueued_deliveries[0 - i]
+        if !params[:via]
+          delivery = delivery.dup
+          delivery.delete(:via)
+        end
+
+        msg = message(msg) { "Expected #{mu_pp(delivery)} to include #{mu_pp(params)}" }
+        assert hash_include?(delivery, params), msg
+      end
+    end
+
+    private
+
+    def deliveries
+      AbstractNotifier::Testing::Driver.deliveries
+    end
+
+    def enqueued_deliveries
+      AbstractNotifier::Testing::Driver.enqueued_deliveries
+    end
+
+    def hash_include?(haystack, needle)
+      needle.all? do |k, v|
+        haystack.key?(k) && haystack[k] == v
+      end
+    end
+  end
+end

--- a/lib/abstract_notifier/testing/rspec.rb
+++ b/lib/abstract_notifier/testing/rspec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  class HaveSentNotification < RSpec::Matchers::BuiltIn::BaseMatcher
+    attr_reader :payload
+
+    def initialize(payload = nil)
+      @payload = payload
+      set_expected_number(:exactly, 1)
+    end
+
+    def exactly(count)
+      set_expected_number(:exactly, count)
+      self
+    end
+
+    def at_least(count)
+      set_expected_number(:at_least, count)
+      self
+    end
+
+    def at_most(count)
+      set_expected_number(:at_most, count)
+      self
+    end
+
+    def times
+      self
+    end
+
+    def once
+      exactly(:once)
+    end
+
+    def twice
+      exactly(:twice)
+    end
+
+    def thrice
+      exactly(:thrice)
+    end
+
+    def supports_block_expectations?
+      true
+    end
+
+    def matches?(proc)
+      raise ArgumentError, "have_sent_notification only supports block expectations" unless Proc === proc
+
+      raise "You can only use have_sent_notification matcher in :test delivery mode" unless AbstractNotifier.test?
+
+      original_deliveries_count = deliveries.count
+      proc.call
+      in_block_deliveries = deliveries.drop(original_deliveries_count)
+
+      @matching_deliveries, @unmatching_deliveries =
+        in_block_deliveries.partition do |actual_payload|
+          next true if payload.nil?
+
+          if payload.is_a?(::Hash) && !payload[:via]
+            actual_payload = actual_payload.dup
+            actual_payload.delete(:via)
+          end
+
+          payload === actual_payload
+        end
+
+      @matching_count = @matching_deliveries.size
+
+      case @expectation_type
+      when :exactly then @expected_number == @matching_count
+      when :at_most then @expected_number >= @matching_count
+      when :at_least then @expected_number <= @matching_count
+      end
+    end
+
+    def deliveries
+      AbstractNotifier::Testing::Driver.deliveries
+    end
+
+    def set_expected_number(relativity, count)
+      @expectation_type = relativity
+      @expected_number =
+        case count
+        when :once then 1
+        when :twice then 2
+        when :thrice then 3
+        else Integer(count)
+        end
+    end
+
+    def failure_message
+      (+"expected to #{verb_present} notification: #{payload_description}").tap do |msg|
+        msg << " #{message_expectation_modifier}, but"
+
+        if @unmatching_deliveries.any?
+          msg << " #{verb_past} the following notifications:"
+          @unmatching_deliveries.each do |unmatching_payload|
+            msg << "\n  #{unmatching_payload}"
+          end
+        else
+          msg << " haven't #{verb_past} anything"
+        end
+      end
+    end
+
+    def failure_message_when_negated
+      "expected not to #{verb_present} #{payload}"
+    end
+
+    def message_expectation_modifier
+      number_modifier = (@expected_number == 1) ? "once" : "#{@expected_number} times"
+      case @expectation_type
+      when :exactly then "exactly #{number_modifier}"
+      when :at_most then "at most #{number_modifier}"
+      when :at_least then "at least #{number_modifier}"
+      end
+    end
+
+    def payload_description
+      if payload.is_a?(RSpec::Matchers::Composable)
+        payload.description
+      else
+        payload
+      end
+    end
+
+    def verb_past
+      "sent"
+    end
+
+    def verb_present
+      "send"
+    end
+  end
+
+  class HaveEnqueuedNotification < HaveSentNotification
+    private
+
+    def deliveries
+      AbstractNotifier::Testing::Driver.enqueued_deliveries
+    end
+
+    def verb_past
+      "enqueued"
+    end
+
+    def verb_present
+      "enqueue"
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(Module.new do
+    def have_sent_notification(*args)
+      AbstractNotifier::HaveSentNotification.new(*args)
+    end
+
+    def have_enqueued_notification(*args)
+      AbstractNotifier::HaveEnqueuedNotification.new(*args)
+    end
+  end)
+end

--- a/lib/abstract_notifier/version.rb
+++ b/lib/abstract_notifier/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module AbstractNotifier
+  VERSION = "0.3.2"
+end

--- a/lib/active_delivery.rb
+++ b/lib/active_delivery.rb
@@ -13,3 +13,6 @@ require "active_delivery/lines/mailer" if defined?(ActionMailer)
 
 require "active_delivery/raitie" if defined?(::Rails::Railtie)
 require "active_delivery/testing" if ENV["RACK_ENV"] == "test" || ENV["RAILS_ENV"] == "test"
+
+require "abstract_notifier"
+require "active_delivery/lines/notifier"

--- a/lib/active_delivery/base.rb
+++ b/lib/active_delivery/base.rb
@@ -204,6 +204,7 @@ module ActiveDelivery
         sync:,
         **delivery.options
       )
+      true
     end
 
     def delivery(notification:, params: nil, options: nil, metadata: nil)

--- a/lib/active_delivery/base.rb
+++ b/lib/active_delivery/base.rb
@@ -93,7 +93,14 @@ module ActiveDelivery
         end
       end
 
-      def register_line(line_id, line_class, **options)
+      def register_line(line_id, line_class = nil, notifier: nil, **options)
+        raise ArgumentError, "A line class or notifier configuration must be provided" if line_class.nil? && notifier.nil?
+
+        # Configure Notifier
+        if line_class.nil?
+          line_class = ActiveDelivery::Lines::Notifier
+        end
+
         delivery_lines[line_id] = line_class.new(id: line_id, owner: self, **options)
 
         instance_eval <<~CODE, __FILE__, __LINE__ + 1

--- a/lib/active_delivery/callbacks.rb
+++ b/lib/active_delivery/callbacks.rb
@@ -37,8 +37,10 @@ module ActiveDelivery
     end
 
     module InstanceExt
-      def do_notify(...)
-        run_callbacks(:notify) { super(...) }
+      def perform_notify(delivery, ...)
+        # We need to store the notification name to be able to use it in callbacks if/unless
+        @notification_name = delivery.notification
+        run_callbacks(:notify) { super(delivery, ...) }
       end
 
       def notify_line(kind, ...)

--- a/lib/active_delivery/lines/base.rb
+++ b/lib/active_delivery/lines/base.rb
@@ -28,7 +28,7 @@ module ActiveDelivery
       end
 
       def notify?(method_name)
-        handler_class.respond_to?(method_name)
+        handler_class&.respond_to?(method_name)
       end
 
       def notify_now(handler, mid, ...)
@@ -58,7 +58,7 @@ module ActiveDelivery
           if class_name
             class_name.is_a?(Class) ? class_name : class_name.safe_constantize
           else
-            resolve_class(owner.name) || superline&.handler_class
+            resolve_class(owner) || superline&.handler_class
           end
       end
 

--- a/lib/active_delivery/lines/mailer.rb
+++ b/lib/active_delivery/lines/mailer.rb
@@ -5,9 +5,10 @@ module ActiveDelivery
     class Mailer < Base
       alias_method :mailer_class, :handler_class
 
-      DEFAULT_RESOLVER = ->(name) { name&.gsub(/Delivery$/, "Mailer")&.safe_constantize }
+      DEFAULT_RESOLVER = ->(klass) { klass.name&.gsub(/Delivery$/, "Mailer")&.safe_constantize }
 
       def notify?(method_name)
+        return unless mailer_class
         mailer_class.action_methods.include?(method_name.to_s)
       end
 

--- a/lib/active_delivery/lines/notifier.rb
+++ b/lib/active_delivery/lines/notifier.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+unless "".respond_to?(:safe_constantize)
+  require "active_delivery/ext/string_constantize"
+  using ActiveDelivery::Ext::StringConstantize
+end
+
+module ActiveDelivery
+  module Lines
+    # AbstractNotifier line for Active Delivery.
+    #
+    # You must provide custom `resolver` to infer notifier class
+    # (if String#safe_constantize is defined, we convert "*Delivery" -> "*Notifier").
+    #
+    # Resolver is a callable object.
+    class Notifier < ActiveDelivery::Lines::Base
+      DEFAULT_SUFFIX = "Notifier"
+
+      def initialize(**opts)
+        super
+        @resolver = opts.fetch(:resolver, build_resolver(options.fetch(:suffix, DEFAULT_SUFFIX)))
+      end
+
+      def resolve_class(klass)
+        resolver&.call(klass)
+      end
+
+      def notify?(method_name)
+        return unless handler_class
+        handler_class.action_methods.include?(method_name.to_s)
+      end
+
+      def notify_now(handler, mid, *args)
+        handler.public_send(mid, *args).notify_now
+      end
+
+      def notify_later(handler, mid, *args)
+        handler.public_send(mid, *args).notify_later
+      end
+
+      private
+
+      attr_reader :resolver
+
+      def build_resolver(suffix)
+        lambda do |klass|
+          klass_name = klass.name
+          klass_name&.sub(/Delivery\z/, suffix)&.safe_constantize
+        end
+      end
+    end
+  end
+end

--- a/lib/active_delivery/testing.rb
+++ b/lib/active_delivery/testing.rb
@@ -18,8 +18,8 @@ module ActiveDelivery
         Thread.current.thread_variable_get(:active_delivery_testing) == true
       end
 
-      def track(delivery, event, args, options)
-        store << [delivery, event, args, options]
+      def track(delivery, options)
+        store << [delivery, options]
       end
 
       def store
@@ -31,9 +31,9 @@ module ActiveDelivery
       end
     end
 
-    def notify(event, *args, **options)
+    def perform_notify(delivery, **options)
       return super unless test?
-      TestDelivery.track(self, event, args, options)
+      TestDelivery.track(delivery, options)
       nil
     end
 

--- a/lib/active_delivery/testing.rb
+++ b/lib/active_delivery/testing.rb
@@ -22,12 +22,21 @@ module ActiveDelivery
         store << [delivery, options]
       end
 
+      def track_line(line)
+        lines << line
+      end
+
       def store
-        @store ||= []
+        Thread.current.thread_variable_get(:active_delivery_testing_store) || Thread.current.thread_variable_set(:active_delivery_testing_store, [])
+      end
+
+      def lines
+        Thread.current.thread_variable_get(:active_delivery_testing_lines) || Thread.current.thread_variable_set(:active_delivery_testing_lines, [])
       end
 
       def clear
         store.clear
+        lines.clear
       end
     end
 
@@ -35,6 +44,11 @@ module ActiveDelivery
       return super unless test?
       TestDelivery.track(delivery, options)
       nil
+    end
+
+    def notify_line(line, ...)
+      res = super
+      TestDelivery.track_line(line) if res
     end
 
     def test?

--- a/spec/abstract_notifier/async_adapters/active_job_spec.rb
+++ b/spec/abstract_notifier/async_adapters/active_job_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ActiveJob adapter", skip: !defined?(ActiveJob) do
+  before { AbstractNotifier.delivery_mode = :normal }
+  after { AbstractNotifier.delivery_mode = :test }
+
+  let(:notifier_class) do
+    AbstractNotifier::TestNotifier =
+      Class.new(AbstractNotifier::Base) do
+        self.driver = TestDriver
+        self.async_adapter = :active_job
+
+        def tested(title, text)
+          notification(
+            body: "Notification #{title}: #{text}"
+          )
+        end
+      end
+  end
+
+  after do
+    AbstractNotifier.send(:remove_const, :TestNotifier) if
+      AbstractNotifier.const_defined?(:TestNotifier)
+  end
+
+  describe "#enqueue" do
+    specify do
+      expect { notifier_class.tested("a", "b").notify_later }
+        .to have_enqueued_job(AbstractNotifier::AsyncAdapters::ActiveJob::DeliveryJob)
+        .with("AbstractNotifier::TestNotifier", body: "Notification a: b")
+        .on_queue("notifiers")
+    end
+
+    context "when queue specified" do
+      before do
+        notifier_class.async_adapter = :active_job, {queue: "test"}
+      end
+
+      specify do
+        expect { notifier_class.tested("a", "b").notify_later }
+          .to have_enqueued_job(
+            AbstractNotifier::AsyncAdapters::ActiveJob::DeliveryJob
+          )
+          .with("AbstractNotifier::TestNotifier", body: "Notification a: b")
+          .on_queue("test")
+      end
+    end
+
+    context "when custom job class specified" do
+      let(:job_class) do
+        AbstractNotifier::TestNotifier::Job = Class.new(ActiveJob::Base)
+      end
+
+      before do
+        notifier_class.async_adapter = :active_job, {job: job_class}
+      end
+
+      specify do
+        expect { notifier_class.tested("a", "b").notify_later }
+          .to have_enqueued_job(job_class)
+          .with("AbstractNotifier::TestNotifier", body: "Notification a: b")
+          .on_queue("notifiers")
+      end
+    end
+  end
+end

--- a/spec/abstract_notifier/base_spec.rb
+++ b/spec/abstract_notifier/base_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe AbstractNotifier::Base do
+  before { AbstractNotifier.delivery_mode = :normal }
+  after { AbstractNotifier.delivery_mode = :test }
+
+  let(:notifier_class) do
+    AbstractNotifier::TestNotifier =
+      Class.new(described_class) do
+        self.driver = TestDriver
+
+        def tested(title, text)
+          notification(
+            body: "Notification #{title}: #{text}"
+          )
+        end
+      end
+  end
+
+  let(:last_delivery) { notifier_class.driver.deliveries.last }
+
+  after do
+    AbstractNotifier.send(:remove_const, :TestNotifier) if
+      AbstractNotifier.const_defined?(:TestNotifier)
+  end
+
+  it "returns Notification object" do
+    expect(notifier_class.tested("Hello", "world")).to be_a(AbstractNotifier::Notification)
+  end
+
+  specify "#notify_later" do
+    expect { notifier_class.tested("a", "b").notify_later }
+      .to change { AbstractNotifier.async_adapter.jobs.size }.by(1)
+
+    notifier, payload = AbstractNotifier.async_adapter.jobs.last
+
+    expect(notifier).to be_eql(notifier_class)
+    expect(payload).to eq(body: "Notification a: b")
+  end
+
+  specify "#notify_now" do
+    expect { notifier_class.tested("a", "b").notify_now }
+      .to change { notifier_class.driver.deliveries.size }.by(1)
+    expect(last_delivery).to eq(body: "Notification a: b")
+  end
+
+  describe ".with" do
+    let(:notifier_class) do
+      AbstractNotifier::TestNotifier =
+        Class.new(described_class) do
+          self.driver = TestDriver
+
+          def tested
+            notification(**params)
+          end
+        end
+    end
+
+    it "sets params" do
+      expect { notifier_class.with(body: "how are you?", to: "123-123").tested.notify_now }
+        .to change { notifier_class.driver.deliveries.size }.by(1)
+
+      expect(last_delivery).to eq(body: "how are you?", to: "123-123")
+    end
+  end
+
+  describe ".default" do
+    context "static defaults" do
+      let(:notifier_class) do
+        AbstractNotifier::TestNotifier =
+          Class.new(described_class) do
+            self.driver = TestDriver
+
+            default action: "TESTO"
+
+            def tested(options = {})
+              notification(**options)
+            end
+          end
+      end
+
+      it "adds defaults to notification if missing" do
+        expect { notifier_class.tested(body: "how are you?", to: "123-123").notify_now }
+          .to change { notifier_class.driver.deliveries.size }.by(1)
+
+        expect(last_delivery).to eq(body: "how are you?", to: "123-123", action: "TESTO")
+      end
+
+      it "doesn't overwrite if key is provided" do
+        expect { notifier_class.tested(body: "how are you?", to: "123-123", action: "OTHER").notify_now }
+          .to change { notifier_class.driver.deliveries.size }.by(1)
+
+        expect(last_delivery).to eq(body: "how are you?", to: "123-123", action: "OTHER")
+      end
+    end
+
+    context "dynamic defaults as method_name" do
+      let(:notifier_class) do
+        AbstractNotifier::TestNotifier =
+          Class.new(described_class) do
+            self.driver = TestDriver
+
+            default :set_defaults
+
+            def tested(options = {})
+              notification(**options)
+            end
+
+            private
+
+            def set_defaults
+              {
+                action: notification_name.to_s.upcase
+              }
+            end
+          end
+      end
+
+      it "adds defaults to notification if missing" do
+        expect { notifier_class.tested(body: "how are you?", to: "123-123").notify_now }
+          .to change { notifier_class.driver.deliveries.size }.by(1)
+
+        expect(last_delivery).to eq(body: "how are you?", to: "123-123", action: "TESTED")
+      end
+
+      it "doesn't overwrite if key is provided" do
+        expect { notifier_class.tested(body: "how are you?", to: "123-123", action: "OTHER").notify_now }
+          .to change { notifier_class.driver.deliveries.size }.by(1)
+
+        expect(last_delivery).to eq(body: "how are you?", to: "123-123", action: "OTHER")
+      end
+    end
+
+    context "dynamic defaults as block" do
+      let(:notifier_class) do
+        AbstractNotifier::TestNotifier =
+          Class.new(described_class) do
+            self.driver = TestDriver
+
+            default do
+              {
+                action: notification_name.to_s.upcase
+              }
+            end
+
+            def tested(options = {})
+              notification(**options)
+            end
+          end
+      end
+
+      it "adds defaults to notification if missing" do
+        expect { notifier_class.tested(body: "how are you?", to: "123-123").notify_now }
+          .to change { notifier_class.driver.deliveries.size }.by(1)
+
+        expect(last_delivery).to eq(body: "how are you?", to: "123-123", action: "TESTED")
+      end
+
+      it "doesn't overwrite if key is provided" do
+        expect { notifier_class.tested(body: "how are you?", to: "123-123", action: "OTHER").notify_now }
+          .to change { notifier_class.driver.deliveries.size }.by(1)
+
+        expect(last_delivery).to eq(body: "how are you?", to: "123-123", action: "OTHER")
+      end
+    end
+  end
+
+  describe ".driver=" do
+    let(:notifier_class) do
+      AbstractNotifier::TestNotifier =
+        Class.new(described_class) do
+          self.driver = TestDriver
+
+          def tested(text)
+            notification(
+              body: "Notification: #{text}",
+              **params
+            )
+          end
+        end
+    end
+
+    let(:fake_driver) { double("driver") }
+
+    around do |ex|
+      old_driver = notifier_class.driver
+      notifier_class.driver = fake_driver
+      ex.run
+      notifier_class.driver = old_driver
+    end
+
+    specify do
+      allow(fake_driver).to receive(:call)
+      notifier_class.with(identity: "qwerty123", tag: "all").tested("fake!").notify_now
+      expect(fake_driver).to have_received(
+        :call
+      ).with(body: "Notification: fake!", identity: "qwerty123", tag: "all")
+    end
+  end
+end

--- a/spec/abstract_notifier/rspec_spec.rb
+++ b/spec/abstract_notifier/rspec_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "RSpec matcher" do
+  let(:notifier_class) do
+    AbstractNotifier::TestNotifier =
+      Class.new(AbstractNotifier::Base) do
+        self.driver = TestDriver
+
+        def tested(title, text)
+          notification(
+            body: "Notification #{title}: #{text}"
+          )
+        end
+      end
+  end
+
+  after do
+    AbstractNotifier.send(:remove_const, :TestNotifier) if
+      AbstractNotifier.const_defined?(:TestNotifier)
+  end
+
+  describe "#have_sent_notification" do
+    specify "success" do
+      expect { notifier_class.tested("a", "b").notify_now }
+        .to have_sent_notification(body: "Notification a: b")
+    end
+
+    specify "failure" do
+      expect do
+        expect { notifier_class.tested("a", "b").notify_now }
+          .to have_sent_notification(body: "Notification a: x")
+      end.to raise_error(/to send notification.+exactly once, but/)
+    end
+
+    specify "composed matchers" do
+      expect { notifier_class.tested("a", "b").notify_now }
+        .to have_sent_notification(a_hash_including(body: /notification/i))
+    end
+
+    context "when delivery_mode is not test" do
+      around do |ex|
+        old_mode = AbstractNotifier.delivery_mode
+        AbstractNotifier.delivery_mode = :noop
+        ex.run
+        AbstractNotifier.delivery_mode = old_mode
+      end
+
+      specify "it raises argument error" do
+        expect do
+          expect { notifier_class.tested("a", "b").notify_now }
+            .to have_sent_notification(body: "Notification a: b")
+        end.to raise_error(/you can only use have_sent_notification matcher in :test delivery mode/i)
+      end
+    end
+  end
+
+  describe "#have_enqueued_notification" do
+    specify "success" do
+      expect { notifier_class.tested("a", "b").notify_later }
+        .to have_enqueued_notification(body: "Notification a: b")
+    end
+
+    specify "failure" do
+      expect do
+        expect { notifier_class.tested("a", "b").notify_now }
+          .to have_enqueued_notification(body: "Notification a: x")
+      end.to raise_error(/to enqueue notification.+exactly once, but/)
+    end
+  end
+end

--- a/spec/active_delivery/base_spec.rb
+++ b/spec/active_delivery/base_spec.rb
@@ -3,21 +3,6 @@
 # rubocop:disable Lint/ConstantDefinitionInBlock
 describe ActiveDelivery::Base do
   before(:all) do
-    class ::QuackLine < ActiveDelivery::Lines::Base
-      def resolve_class(klass)
-        ::DeliveryTesting.const_get(klass.name.gsub(/Delivery$/, options.fetch(:suffix, "Quack")))
-      rescue
-      end
-
-      def notify_now(handler, ...)
-        handler.public_send(...).quack_quack
-      end
-
-      def notify_later(handler, ...)
-        handler.public_send(...).quack_later
-      end
-    end
-
     ActiveDelivery::Base.register_line :quack, QuackLine
     ActiveDelivery::Base.register_line :quack_quack, QuackLine, suffix: "Quackkk"
   end
@@ -28,6 +13,11 @@ describe ActiveDelivery::Base do
 
   after do
     Object.send(:remove_const, :DeliveryTesting)
+  end
+
+  after(:all) do
+    ActiveDelivery::Base.unregister_line :quack
+    ActiveDelivery::Base.unregister_line :quack_quack
   end
 
   let(:delivery_class) do

--- a/spec/active_delivery/base_spec.rb
+++ b/spec/active_delivery/base_spec.rb
@@ -126,6 +126,31 @@ describe ActiveDelivery::Base do
           .to raise_error(/Quack krya!/)
       end
     end
+
+    context "when .deliver_actions_required is true" do
+      around do |ex|
+        was_val = ActiveDelivery.deliver_actions_required
+        ActiveDelivery.deliver_actions_required = true
+        ex.run
+        ActiveDelivery.deliver_actions_required = was_val
+      end
+
+      it "raises NoMethodError" do
+        expect { delivery_class.do_something.deliver_later }
+          .to raise_error(NoMethodError)
+      end
+
+      context "when action is specified via #delivers" do
+        before do
+          delivery_class.delivers :do_something
+        end
+
+        it "calls quack_later" do
+          expect { delivery_class.do_something.deliver_later }
+            .to raise_error(/do_something will be quacked later/)
+        end
+      end
+    end
   end
 
   describe ".unregister_line" do
@@ -182,7 +207,7 @@ describe ActiveDelivery::Base do
     end
 
     it "calls with on line class" do
-      expect { delivery_class.with(id: 15, name: "Maldyak").notify(:do_something) }
+      expect { delivery_class.with(id: 15, name: "Maldyak").do_something.deliver_later }
         .to raise_error(/do_something with 15 and Maldyak will be quacked later/)
     end
   end

--- a/spec/active_delivery/base_spec.rb
+++ b/spec/active_delivery/base_spec.rb
@@ -4,8 +4,8 @@
 describe ActiveDelivery::Base do
   before(:all) do
     class ::QuackLine < ActiveDelivery::Lines::Base
-      def resolve_class(name)
-        ::DeliveryTesting.const_get(name.gsub(/Delivery$/, options.fetch(:suffix, "Quack")))
+      def resolve_class(klass)
+        ::DeliveryTesting.const_get(klass.name.gsub(/Delivery$/, options.fetch(:suffix, "Quack")))
       rescue
       end
 

--- a/spec/active_delivery/lines/notifier_spec.rb
+++ b/spec/active_delivery/lines/notifier_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ActiveDelivery::Lines::Notifier do
+  before do
+    module ::DeliveryTesting # rubocop:disable Lint/ConstantDefinitionInBlock
+      class TestNotifier < AbstractNotifier::Base
+        def do_something(msg)
+          notification(
+            body: msg,
+            to: params[:user]
+          )
+        end
+
+        private
+
+        def do_nothing
+        end
+      end
+
+      class TestReverseNotifier < AbstractNotifier::Base
+        def do_something(msg)
+          notification(
+            body: msg.reverse,
+            to: params[:user]
+          )
+        end
+      end
+
+      class CustomNotifier < AbstractNotifier::Base
+        def do_something(msg)
+          notification(
+            body: "[CUSTOM] #{msg}",
+            to: params[:user]
+          )
+        end
+      end
+
+      class TestDelivery < ActiveDelivery::Base
+        register_line :notifier, notifier: true
+        register_line :reverse_notifier, notifier: true, suffix: "ReverseNotifier"
+        register_line :custom_notifier, notifier: true,
+          resolver: proc { CustomNotifier }
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :DeliveryTesting)
+  end
+
+  let(:delivery_class) { ::DeliveryTesting::TestDelivery }
+  let(:notifier_class) { ::DeliveryTesting::TestNotifier }
+  let(:reverse_notifier_class) { ::DeliveryTesting::TestReverseNotifier }
+  let(:custom_notifier_class) { ::DeliveryTesting::CustomNotifier }
+
+  describe ".notifier_class" do
+    it "infers notifier from delivery name" do
+      expect(delivery_class.notifier_class).to be_eql(notifier_class)
+      expect(delivery_class.reverse_notifier_class).to be_eql(reverse_notifier_class)
+      expect(delivery_class.custom_notifier_class).to be_eql(custom_notifier_class)
+    end
+  end
+
+  describe ".notify" do
+    describe ".notify" do
+      it "enqueues notification" do
+        expect { delivery_class.with(user: "Shnur").do_something("Magic people voodoo people!").deliver_later }
+          .to have_enqueued_notification(via: notifier_class, body: "Magic people voodoo people!", to: "Shnur")
+          .and have_enqueued_notification(via: reverse_notifier_class, body: "!elpoep oodoov elpoep cigaM", to: "Shnur")
+          .and have_enqueued_notification(via: custom_notifier_class, body: "[CUSTOM] Magic people voodoo people!", to: "Shnur")
+      end
+
+      it "do nothing when notifier doesn't have provided public method" do
+        expect { delivery_class.notify(:do_nothing) }
+          .not_to have_enqueued_notification
+      end
+    end
+
+    describe ".notify!" do
+      it "sends notification" do
+        expect { delivery_class.with(user: "Shnur").notify!(:do_something, "Voyage-voyage!") }
+          .to have_sent_notification(via: notifier_class, body: "Voyage-voyage!", to: "Shnur")
+          .and have_sent_notification(via: reverse_notifier_class, body: "!egayov-egayoV", to: "Shnur")
+          .and have_sent_notification(via: custom_notifier_class, body: "[CUSTOM] Voyage-voyage!", to: "Shnur")
+      end
+    end
+  end
+end

--- a/spec/active_delivery/rspec_spec.rb
+++ b/spec/active_delivery/rspec_spec.rb
@@ -15,12 +15,19 @@ describe "RSpec matcher" do
           def send_something(...)
             new.send_something(...)
           end
+
+          def send_anything(...)
+            new.send_anything(...)
+          end
         end
 
         def initialize(*)
         end
 
         def send_something(*)
+        end
+
+        def send_anything(*)
         end
       end
 
@@ -32,103 +39,150 @@ describe "RSpec matcher" do
 
   after(:all) do
     Object.send(:remove_const, :DeliveryTesting)
+    ActiveDelivery::Base.unregister_line :testo
   end
 
   let(:delivery) { ::DeliveryTesting::Delivery }
 
-  context "success" do
-    specify "with only delivery class" do
-      expect { delivery.send_something("data", 42).deliver_later }
-        .to have_delivered_to(delivery)
-    end
-
-    specify "with #deliver_now" do
-      expect { delivery.send_something("data", 42).deliver_now }
-        .to have_delivered_to(delivery).synchronously
-    end
-
-    specify "with delivery class and arguments" do
-      expect { delivery.notify(:send_something, "data", 42) }
-        .to have_delivered_to(delivery, :send_something, a_string_matching(/da/), 42)
-    end
-
-    specify "with times" do
-      expect { delivery.notify(:send_something, "data", 42) }
-        .to have_delivered_to(delivery).once
-    end
-
-    specify "when multiple times" do
-      expect do
-        delivery.notify(:send_something, "data", 42)
-        delivery.notify(:send_something, "data", 45)
-      end.to have_delivered_to(delivery).twice
-        .and have_delivered_to(delivery, :send_something, "data", 42).once
-        .and have_delivered_to(delivery, :send_something, "data", 45).once
-    end
-
-    specify "with params" do
-      expect { delivery.with(id: 42).notify(:send_something, "data") }
-        .to have_delivered_to(delivery, :send_something, "data").with(id: 42)
-    end
-
-    context "negatiation" do
-      specify "not_to" do
-        expect { true }.not_to have_delivered_to(delivery)
-      end
-
-      specify "have_not_delivered_to" do
-        expect { true }.to have_not_delivered_to(delivery)
-      end
-    end
-  end
-
-  context "failure" do
-    specify "when no delivery was made" do
-      expect do
-        expect { true }
+  describe "#have_delivered_to" do
+    context "success" do
+      specify "with only delivery class" do
+        expect { delivery.send_something("data", 42).deliver_later }
           .to have_delivered_to(delivery)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      specify "with #deliver_now" do
+        expect { delivery.send_something("data", 42).deliver_now }
+          .to have_delivered_to(delivery).synchronously
+      end
+
+      specify "with delivery class and arguments" do
+        expect { delivery.notify(:send_something, "data", 42) }
+          .to have_delivered_to(delivery, :send_something, a_string_matching(/da/), 42)
+      end
+
+      specify "with times" do
+        expect { delivery.notify(:send_something, "data", 42) }
+          .to have_delivered_to(delivery).once
+      end
+
+      specify "when multiple times" do
+        expect do
+          delivery.notify(:send_something, "data", 42)
+          delivery.notify(:send_something, "data", 45)
+        end.to have_delivered_to(delivery).twice
+          .and have_delivered_to(delivery, :send_something, "data", 42).once
+          .and have_delivered_to(delivery, :send_something, "data", 45).once
+      end
+
+      specify "with params" do
+        expect { delivery.with(id: 42).notify(:send_something, "data") }
+          .to have_delivered_to(delivery, :send_something, "data").with(id: 42)
+      end
+
+      context "negatiation" do
+        specify "not_to" do
+          expect { true }.not_to have_delivered_to(delivery)
+        end
+
+        specify "have_not_delivered_to" do
+          expect { true }.to have_not_delivered_to(delivery)
+        end
+      end
     end
 
-    specify "with wrong action" do
-      expect do
-        expect { delivery.notify(:send_something) }
-          .to have_delivered_to(delivery, :send_smth)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    context "failure" do
+      specify "when no delivery was made" do
+        expect do
+          expect { true }
+            .to have_delivered_to(delivery)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      specify "with wrong action" do
+        expect do
+          expect { delivery.notify(:send_something) }
+            .to have_delivered_to(delivery, :send_smth)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      specify "with wrong arguments" do
+        expect do
+          expect { delivery.notify(:send_something, "fail") }
+            .to have_delivered_to(delivery, :send_something, "foil")
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      specify "with wrong params" do
+        expect do
+          expect { delivery.with(id: 13).notify(:send_something) }
+            .to have_delivered_to(delivery, :send_something).with(id: 31)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
+
+      specify "with wrong number of times" do
+        expect do
+          expect { delivery.notify(:send_something) }
+            .to have_delivered_to(delivery, :send_something).twice
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
     end
 
-    specify "with wrong arguments" do
-      expect do
-        expect { delivery.notify(:send_something, "fail") }
-          .to have_delivered_to(delivery, :send_something, "foil")
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-    end
+    context "fibers" do
+      specify "success" do
+        expect { Fiber.new { delivery.notify(:send_something, "data", 42) }.resume }
+          .to have_delivered_to(delivery)
+      end
 
-    specify "with wrong params" do
-      expect do
-        expect { delivery.with(id: 13).notify(:send_something) }
-          .to have_delivered_to(delivery, :send_something).with(id: 31)
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-    end
-
-    specify "with wrong number of times" do
-      expect do
-        expect { delivery.notify(:send_something) }
-          .to have_delivered_to(delivery, :send_something).twice
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      specify "failure" do
+        expect do
+          expect { Fiber.new { delivery.notify(:send_something) }.resume }
+            .to have_delivered_to(delivery, :send_smth)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
     end
   end
 
-  context "fibers" do
+  describe "#deliver_via", type: :delivery, skip: !defined?(ActiveSupport) do
+    before(:all) do
+      module ::DeliveryTesting
+        class DuckDelivery < Delivery
+          register_line :quack, QuackLine
+          quack(Class.new do
+            def self.send_something(...) = Quack.new
+
+            def self.send_anything(...) = Quack.new
+          end)
+
+          before_notify :skip_quack, on: :quack, only: :send_anything
+
+          private
+
+          def skip_quack
+            false
+          end
+        end
+      end
+    end
+
+    let(:delivery) { DeliveryTesting::DuckDelivery }
+
     specify "success" do
-      expect { Fiber.new { delivery.notify(:send_something, "data", 42) }.resume }
-        .to have_delivered_to(delivery)
+      expect { delivery.send_something("data", 42).deliver_later }
+        .to deliver_via(:testo, :quack)
+      expect { delivery.send_anything("data").deliver_now }
+        .to deliver_via(:testo)
     end
 
     specify "failure" do
       expect do
-        expect { Fiber.new { delivery.notify(:send_something) }.resume }
-          .to have_delivered_to(delivery, :send_smth)
+        expect { delivery.send_something("data", 42).deliver_later }
+          .to deliver_via(:quack)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+
+      expect do
+        expect { delivery.send_anything("data").deliver_now }
+          .to deliver_via(:testo, :quack)
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end

--- a/spec/active_delivery/rspec_spec.rb
+++ b/spec/active_delivery/rspec_spec.rb
@@ -38,8 +38,13 @@ describe "RSpec matcher" do
 
   context "success" do
     specify "with only delivery class" do
-      expect { delivery.notify(:send_something, "data", 42) }
+      expect { delivery.send_something("data", 42).deliver_later }
         .to have_delivered_to(delivery)
+    end
+
+    specify "with #deliver_now" do
+      expect { delivery.send_something("data", 42).deliver_now }
+        .to have_delivered_to(delivery).synchronously
     end
 
     specify "with delivery class and arguments" do

--- a/spec/support/quack.rb
+++ b/spec/support/quack.rb
@@ -17,3 +17,18 @@ class Quack
     raise "Quack #{mid}!"
   end
 end
+
+class QuackLine < ActiveDelivery::Lines::Base
+  def resolve_class(klass)
+    ::DeliveryTesting.const_get(klass.name.gsub(/Delivery$/, options.fetch(:suffix, "Quack")))
+  rescue
+  end
+
+  def notify_now(handler, ...)
+    handler.public_send(...).quack_quack
+  end
+
+  def notify_later(handler, ...)
+    handler.public_send(...).quack_later
+  end
+end


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR tracks the development of v1.0, which will introduce a bunch of major changes.

## What changes did you make?

- [x] Added ActionMailer-like API to send notifications: `MyDelivery.notify(:x, a) -> MyDelivery.x(a).deliver_later`.
- [x] Added `#deliver_via` matcher to test deliveries (as alternative to shared examples provided in the Readme)
- [x] Merged [abstract_notifier][]—it makes sense to develop and release these two gems together

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation


[abstract_notifier]: https://github.com/palkan/abstract_notifier

